### PR TITLE
Adding tunnel id cap detection/application to the sauce helper.

### DIFF
--- a/src/test/java/com/yourcompany/Tests/SampleSauceTestBase.java
+++ b/src/test/java/com/yourcompany/Tests/SampleSauceTestBase.java
@@ -180,7 +180,7 @@ public class SampleSauceTestBase implements SauceOnDemandSessionIdProvider {
         if (buildTag != null) {
             capabilities.setCapability("build", buildTag);
         }
-
+        SauceHelpers.addSauceConnectTunnelId(capabilities);
         this.driver = new RemoteWebDriver(
                 new URL("http://" + username+ ":" + accesskey + seleniumURI +"/wd/hub"),
                 capabilities);

--- a/src/test/java/com/yourcompany/Utils/SauceHelpers.java
+++ b/src/test/java/com/yourcompany/Utils/SauceHelpers.java
@@ -1,5 +1,7 @@
 package com.yourcompany.Utils;
 
+import org.openqa.selenium.remote.DesiredCapabilities;
+
 /**
  * Created by mehmetgerceker on 12/9/15.
  */
@@ -35,4 +37,28 @@ public class SauceHelpers {
     public static String buildSauceUri() {
         return buildSauceUri(false);
     }
+
+    /**
+     * Adds/updates sauce tunnel id to desired capabilities in place
+     * @param desiredCapabilities desired caps
+     * @param tunnelId tunnel id
+     */
+    public static void addSauceConnectTunnelId(DesiredCapabilities desiredCapabilities, String tunnelId) {
+        if (tunnelId == null || tunnelId.length() == 0) {
+            tunnelId = System.getenv("TUNNEL_IDENTIFIER");
+        }
+
+        if (tunnelId != null && tunnelId.length() > 0){
+            desiredCapabilities.setCapability("tunnel-identifier", tunnelId);
+        }
+    }
+
+    /**
+     * Adds/updates sauce tunnel id to desired capabilities from env in place
+     * @param desiredCapabilities desired caps
+     */
+    public static void addSauceConnectTunnelId(DesiredCapabilities desiredCapabilities) {
+        addSauceConnectTunnelId(desiredCapabilities, null);
+    }
+
 }


### PR DESCRIPTION
Example improved to use sauce connect tunnel with the jenkins plugin. Named tunnels created by the plugin need to have this update to work through SC tunnels. 